### PR TITLE
Hackily remove parent selector from :root selectors

### DIFF
--- a/index.js
+++ b/index.js
@@ -20,6 +20,9 @@ function scope (css, parent) {
 	//revoke wrongly replaced @ statements, like @supports, @import, @media etc.
 	css = css.replace(new RegExp('(' + parentRe + ')\\s*@', 'g'), '@');
 
+	//revoke wrongly replaced :root blocks
+	css = css.replace(new RegExp('(' + parentRe + ')\\s*:root', 'g'), ':root');
+
 	return css;
 }
 

--- a/test.js
+++ b/test.js
@@ -23,6 +23,17 @@ assert.equal(scope(
 .settings-panel {font-size: 11px;}
 `);
 
+//ignore :root
+assert.equal(scope(
+`
+.settings-panel-label {font-size: var(--font-size);}
+:root {--font-size: 11px;}
+`,'.settings-panel'),
+`
+.settings-panel .settings-panel-label {font-size: var(--font-size);}
+:root {--font-size: 11px;}
+`);
+
 //readme case
 assert.equal(scope(`
 .panel {}


### PR DESCRIPTION
Prevent `:root` selector being prepended with parent selector

e.g.
```css
/* with this PR */
:root {
    --color: rebeccapurple;
}

/* previously */
.parent :root {
    --color: rebeccapurple;
}
```